### PR TITLE
not pass optional params on OSX if empty

### DIFF
--- a/OSXNotifier.go
+++ b/OSXNotifier.go
@@ -27,7 +27,17 @@ type osxNotifier struct {
 
 // Notify sends a notification to the user.
 func (n *osxNotifier) Notify(msg *Notification) error {
-	cmd := exec.Command(n.path, "-message", msg.Message, "-title", msg.Title, "-open", msg.ClickURL, "-appIcon", msg.IconURL)
+	args := []string{
+		"-message", msg.Message,
+		"-title", msg.Title,
+	}
+	if msg.ClickURL != "" {
+		args = append(args, []string{"-open", msg.ClickURL}...)
+	}
+	if msg.IconURL != "" {
+		args = append(args, []string{"-appIcon", msg.IconURL}...)
+	}
+	cmd := exec.Command(n.path, args...)
 	result, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Errorf("Could not run command %v", err)

--- a/example/example.go
+++ b/example/example.go
@@ -13,7 +13,7 @@ func main() {
 		Title:    "Super Important",
 		Message:  "Free the Internet",
 		ClickURL: "https://www.getlantern.org",
-		//IconURL:  "https://www.getlantern.org",
+		IconURL:  "https://www.getlantern.org/static/images/favicon.png",
 	}
 
 	n.Notify(msg)

--- a/notifier.go
+++ b/notifier.go
@@ -25,14 +25,10 @@ type Notifier interface {
 // is directly modeled after Chrome notifications, as detailed at:
 // https://developer.chrome.com/apps/notifications
 type Notification struct {
-	ID                 string
-	Type               string
-	Title              string
-	Message            string
-	IconURL            string
-	RequireInteraction bool
-	IsClickable        bool
-	ClickURL           string
+	Title    string
+	Message  string
+	IconURL  string
+	ClickURL string
 }
 
 type emptyNotifier struct {


### PR DESCRIPTION
Passing empty string to `-open` would cause a dialog showing something like "invalid URL @+" (can't remember, couldn't reproduce due to #2) 